### PR TITLE
Rename CLI to dotsync; add doctor, standalone installer, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,13 @@ this repository. Humans: see [README.md](README.md).
 
 ## What this project is
 
-`git-config-sync` syncs a user's git/shell dotfiles across machines via a Git repo
+`dotsync` syncs a user's git/shell dotfiles across machines via a Git repo
 and symbolic links. It ships:
 
-- `bin/git-config-sync` — a dependency-free bash CLI (the core logic).
+- `bin/dotsync` — a dependency-free bash CLI (the core logic).
 - `config/` — the dotfiles that get symlinked into `$HOME`.
 - `sync.map` — the manifest mapping `config/*` files to `$HOME` targets.
-- `install.sh` — a one-shot installer that wires everything up.
+- `install.sh` — an installer (works via `curl | bash` or from a local clone).
 - `scripts/secure-packages.sh` — optional npm hardening.
 
 ## Golden rules
@@ -43,13 +43,14 @@ and symbolic links. It ships:
 Run these checks and make sure they pass:
 
 ```bash
-bash -n bin/git-config-sync install.sh scripts/secure-packages.sh   # syntax
-shellcheck bin/git-config-sync install.sh scripts/secure-packages.sh # if available
+bash -n bin/dotsync install.sh scripts/secure-packages.sh   # syntax
+shellcheck bin/dotsync install.sh scripts/secure-packages.sh # if available
 
 # End-to-end smoke test against a throwaway HOME (never your real one):
 TMP="$(mktemp -d)"
-HOME="$TMP" GIT_CONFIG_SYNC_DIR="$PWD" bash bin/git-config-sync link
-HOME="$TMP" GIT_CONFIG_SYNC_DIR="$PWD" bash bin/git-config-sync unlink
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync link
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync doctor
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync unlink
 rm -rf "$TMP"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to git-config-sync
+# Contributing to dotsync
 
-Thanks for your interest in improving `git-config-sync`! This project is a small,
+Thanks for your interest in improving `dotsync`! This project is a small,
 dependency-free bash tool plus a dotfiles template, so contributions are easy to
 make and easy to review. This guide explains how.
 
@@ -31,22 +31,23 @@ make and easy to review. This guide explains how.
 ## Development setup
 
 ```bash
-git clone https://github.com/<your-fork>/git-config-sync.git
-cd git-config-sync
+git clone https://github.com/<your-fork>/dotsync.git
+cd dotsync
 ```
 
 There's nothing to build. Run the CLI directly:
 
 ```bash
-bash bin/git-config-sync help
+bash bin/dotsync help
 ```
 
 **Always test against a throwaway `$HOME`** so you never touch your real dotfiles:
 
 ```bash
 TMP="$(mktemp -d)"
-HOME="$TMP" GIT_CONFIG_SYNC_DIR="$PWD" bash bin/git-config-sync link
-HOME="$TMP" GIT_CONFIG_SYNC_DIR="$PWD" bash bin/git-config-sync unlink
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync link
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync doctor
+HOME="$TMP" DOTSYNC_DIR="$PWD" bash bin/dotsync unlink
 rm -rf "$TMP"
 ```
 
@@ -67,10 +68,10 @@ Make sure these pass:
 
 ```bash
 # Syntax check
-bash -n bin/git-config-sync install.sh scripts/secure-packages.sh
+bash -n bin/dotsync install.sh scripts/secure-packages.sh
 
 # Static analysis (if installed)
-shellcheck bin/git-config-sync install.sh scripts/secure-packages.sh
+shellcheck bin/dotsync install.sh scripts/secure-packages.sh
 
 # End-to-end smoke test against a throwaway HOME (see above)
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-config-sync
+# dotsync
 
 Keep your **git and shell configuration in sync across every machine** using a
 Git repository and symbolic links.
@@ -14,14 +14,15 @@ The idea is simple and battle-tested:
    home.
 
 This repo is both a **ready-to-use template** you can fork and fill with your own
-config, and a small **CLI (`git-config-sync`)** that automates the clone / link /
-push / pull cycle.
+config, and a small **CLI (`dotsync`)** that automates the clone / link / push /
+pull cycle.
 
 ---
 
 ## Table of contents
 
 - [Why symlinks?](#why-symlinks)
+- [Installation](#installation)
 - [Repository layout](#repository-layout)
 - [Quick start](#quick-start)
 - [Making it your own](#making-it-your-own)
@@ -33,7 +34,9 @@ push / pull cycle.
   - [npm security defaults](#npm-security-defaults)
 - [Security notes](#security-notes)
 - [Manual usage (no CLI)](#manual-usage-no-cli)
+- [Design decisions & roadmap](#design-decisions--roadmap)
 - [Uninstall](#uninstall)
+- [Contributing](#contributing)
 - [References](#references)
 
 ---
@@ -53,12 +56,51 @@ change on its next `pull`.
 
 ---
 
+## Installation
+
+Install just the CLI, straight from the internet:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/adonyssantos/dotsync/main/install.sh | bash
+```
+
+This clones `dotsync` into `~/.local/share/dotsync` and symlinks the `dotsync`
+command into `~/.local/bin`. Make sure that directory is on your `PATH`:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"   # add to your ~/.bashrc / ~/.zshrc
+```
+
+<details>
+<summary><strong>Manual install</strong></summary>
+
+```bash
+git clone https://github.com/adonyssantos/dotsync.git ~/.local/share/dotsync
+ln -s ~/.local/share/dotsync/bin/dotsync ~/.local/bin/dotsync
+```
+</details>
+
+### Windows
+
+`dotsync` is a bash script. On Windows, run it under **Git Bash** (ships with
+[Git for Windows](https://gitforwindows.org/)) or **WSL** — the `curl | bash`
+line above works unchanged in either. Symlinks need Developer Mode or an elevated
+shell; Git Bash handles this transparently for files inside your home directory.
+
+After installing, verify everything with:
+
+```bash
+dotsync doctor
+```
+
+---
+
 ## Repository layout
 
 ```
-git-config-sync/
+dotsync/
 ├── bin/
-│   └── git-config-sync      # the CLI (bash, no dependencies)
+│   └── dotsync              # the CLI (bash, no dependencies)
 ├── config/
 │   ├── gitconfig            # → ~/.gitconfig
 │   ├── gitignore_global     # → ~/.gitignore_global
@@ -66,7 +108,7 @@ git-config-sync/
 ├── scripts/
 │   └── secure-packages.sh   # optional npm hardening
 ├── sync.map                 # manifest: which file links where
-├── install.sh               # one-shot installer for this template
+├── install.sh               # installer (curl-pipe or local)
 ├── AGENTS.md                # guidance for AI coding agents
 ├── CONTRIBUTING.md          # how to contribute
 └── README.md
@@ -87,22 +129,24 @@ Add your own lines to sync more files (e.g. `config/tmux.conf  .tmux.conf`).
 ## Quick start
 
 ```bash
-# 1. Clone this template (or your fork of it)
-git clone https://github.com/adonyssantos/git-config-sync.git ~/DEVELOPMENT/dotfiles
-cd ~/DEVELOPMENT/dotfiles
+# 1. Install the CLI (see Installation above)
+curl -fsSL https://raw.githubusercontent.com/adonyssantos/dotsync/main/install.sh | bash
 
-# 2. Run the installer — it installs the CLI, creates the symlinks,
-#    appends the shell aliases, and optionally hardens npm.
-bash install.sh
+# 2. Point dotsync at your dotfiles repo and link it into $HOME
+dotsync init https://github.com/<you>/<your-dotfiles>.git
+dotsync link
 
-# 3. Load the new aliases and set your identity
-source ~/.bashrc
+# 3. Set your git identity and verify
 git config --global user.name  "Your Name"
 git config --global user.email "you@example.com"
+dotsync doctor
 ```
 
-`install.sh` backs up anything it would overwrite as `<file>.bak`, so it's safe to
-run on a machine that already has a `~/.gitconfig`.
+`link` backs up anything it would overwrite as `<file>.bak`, so it's safe to run
+on a machine that already has a `~/.gitconfig`.
+
+> **Using this repo itself as your dotfiles?** Clone it and run `bash install.sh`
+> from inside the clone — it will offer to link *its* config into your `$HOME`.
 
 ---
 
@@ -115,42 +159,39 @@ run on a machine that already has a `~/.gitconfig`.
 4. Commit and push. From then on:
 
    ```bash
-   git-config-sync push "add tmux config"   # commit + push your changes
-   git-config-sync pull                      # on another machine: pull + re-link
+   dotsync push "add tmux config"   # commit + push your changes
+   dotsync pull                     # on another machine: pull + re-link
    ```
-
-On every new machine you only need:
-
-```bash
-git-config-sync init https://github.com/<you>/<your-dotfiles>.git
-git-config-sync link
-```
 
 ---
 
 ## CLI reference
 
-Once installed, `git-config-sync` is on your `PATH` (via `~/.local/bin`). It
-remembers which repository is your "config repo" in
-`~/.config/git-config-sync/state`.
+Once installed, `dotsync` is on your `PATH` (via `~/.local/bin`). It remembers
+which repository is your "config repo" in `~/.config/dotsync/state`.
 
 | Command | Description |
 |---------|-------------|
-| `git-config-sync init <repo-url> [dir]` | Clone your config repo (default dir `~/DEVELOPMENT/dotfiles`) and remember it |
-| `git-config-sync use <dir>` | Point the CLI at an existing local clone |
-| `git-config-sync link` | Create the symlinks from `sync.map` and append the shell aliases |
-| `git-config-sync unlink` | Remove the symlinks and the alias block (restores any `.bak` backups) |
-| `git-config-sync push [message]` | `git add -A`, commit, and push in the config repo |
-| `git-config-sync pull` | `git pull --ff-only`, then re-link |
-| `git-config-sync status` | Show `git status` for the config repo |
-| `git-config-sync where` | Print the resolved config repo path |
-| `git-config-sync help` | Show usage |
+| `dotsync init <repo-url> [dir]` | Clone your config repo (default dir `~/DEVELOPMENT/dotfiles`) and remember it |
+| `dotsync use <dir>` | Point the CLI at an existing local clone |
+| `dotsync link` | Create the symlinks from `sync.map` and append the shell aliases |
+| `dotsync unlink` | Remove the symlinks and the alias block (restores any `.bak` backups) |
+| `dotsync push [message]` | `git add -A`, commit, and push in the config repo |
+| `dotsync pull` | `git pull --ff-only`, then re-link |
+| `dotsync status` | Show `git status` for the config repo |
+| `dotsync doctor` | Diagnose your setup: git, PATH, remote auth, and link status |
+| `dotsync where` | Print the resolved config repo path |
+| `dotsync help` | Show usage |
 
 **How the active repo is resolved** (first match wins):
 
-1. `$GIT_CONFIG_SYNC_DIR` environment variable
+1. `$DOTSYNC_DIR` environment variable
 2. the path saved by `init` / `use`
-3. the repository the `git-config-sync` script itself lives in (if it has a `sync.map`)
+3. the repository the `dotsync` script itself lives in (if it has a `sync.map`)
+
+> **Coming from the [original issue](https://github.com/adonyssantos/dotsync/issues/4)?**
+> The proposed `set <folder> <repo>` maps to `dotsync init <repo> [dir]`, and there
+> is deliberately no `login` command — see [Design decisions](#design-decisions--roadmap).
 
 ---
 
@@ -255,11 +296,33 @@ Then commit and push from the repo as usual.
 
 ---
 
+## Design decisions & roadmap
+
+- **Auth is delegated to git — there is no `dotsync login`.** Re-implementing
+  GitHub authentication would add a security surface and duplicate what git
+  already does well. `dotsync` uses whatever credentials git is already
+  configured with (SSH keys, a credential helper, or `gh auth`). `dotsync doctor`
+  tests remote reachability and points you at the right fix when auth fails.
+- **`init` / `use` instead of `set-folder` / `set-repo`.** The original issue
+  proposed `set <folder> <repo>`; that is covered by `dotsync init <repo> [dir]`,
+  which also does the initial clone. Kept to two verbs to keep the surface small.
+- **No npm package or prebuilt binaries (for now).** The CLI is intentionally
+  dependency-free bash so it runs anywhere without a toolchain. Distribution is
+  handled by the `curl | bash` installer above; a Homebrew formula is the likely
+  next step. Prebuilt binaries would only make sense after a rewrite in a compiled
+  language, which isn't warranted yet.
+- **A public "catalog" of shared configs is out of scope.** That's a separate
+  product (a web app), not part of this CLI, and would be tracked in its own repo.
+
+---
+
 ## Uninstall
 
 ```bash
-git-config-sync unlink          # remove symlinks + alias block, restore backups
-rm ~/.local/bin/git-config-sync # remove the CLI shim
+dotsync unlink                  # remove symlinks + alias block, restore backups
+rm ~/.local/bin/dotsync         # remove the CLI shim
+rm -rf ~/.local/share/dotsync   # remove the cloned CLI (if installed via curl)
+rm -rf ~/.config/dotsync        # remove saved state
 ```
 
 ---

--- a/bin/dotsync
+++ b/bin/dotsync
@@ -1,31 +1,32 @@
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────────────────────
-# git-config-sync — keep your git & shell config in sync across machines
+# dotsync — keep your git & shell config in sync across machines
 # using a Git repository and symbolic links.
 #
-#   git-config-sync init <repo-url> [dir]   Clone your config repo and remember it
-#   git-config-sync use  <dir>              Point at an existing local clone
-#   git-config-sync link                    Symlink tracked files into $HOME
-#   git-config-sync unlink                  Remove the symlinks / alias block
-#   git-config-sync push [message]          Commit all changes and push
-#   git-config-sync pull                    Pull latest, then re-link
-#   git-config-sync status                  Show the config repo's git status
-#   git-config-sync where                   Print the resolved config repo path
-#   git-config-sync help                    Show this help
+#   dotsync init <repo-url> [dir]   Clone your config repo and remember it
+#   dotsync use  <dir>              Point at an existing local clone
+#   dotsync link                    Symlink tracked files into $HOME
+#   dotsync unlink                  Remove the symlinks / alias block
+#   dotsync push [message]          Commit all changes and push
+#   dotsync pull                    Pull latest, then re-link
+#   dotsync status                  Show the config repo's git status
+#   dotsync doctor                  Diagnose your setup (git, PATH, auth, links)
+#   dotsync where                   Print the resolved config repo path
+#   dotsync help                    Show this help
 #
 # The active config repo is resolved in this order:
-#   1. $GIT_CONFIG_SYNC_DIR
-#   2. the path saved by `init`/`use` (in $XDG_CONFIG_HOME/git-config-sync/state)
+#   1. $DOTSYNC_DIR
+#   2. the path saved by `init`/`use` (in $XDG_CONFIG_HOME/dotsync/state)
 #   3. the repository this script lives in (if it contains a sync.map)
 # ─────────────────────────────────────────────────────────────────────────────
 
 set -euo pipefail
 
-readonly PROG="git-config-sync"
-readonly STATE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/git-config-sync"
+readonly PROG="dotsync"
+readonly STATE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dotsync"
 readonly STATE_FILE="$STATE_DIR/state"
-readonly ALIAS_BEGIN="# BEGIN git-config-sync aliases"
-readonly ALIAS_END="# END git-config-sync aliases"
+readonly ALIAS_BEGIN="# BEGIN dotsync aliases"
+readonly ALIAS_END="# END dotsync aliases"
 
 # ── helpers ─────────────────────────────────────────────────────────────────
 info()  { printf '\033[0;34m==>\033[0m %s\n' "$*"; }
@@ -51,8 +52,8 @@ save_repo_dir() {
 
 # Resolve the active config repo directory.
 resolve_repo_dir() {
-    if [ -n "${GIT_CONFIG_SYNC_DIR:-}" ]; then
-        printf '%s\n' "$GIT_CONFIG_SYNC_DIR"; return 0
+    if [ -n "${DOTSYNC_DIR:-}" ]; then
+        printf '%s\n' "$DOTSYNC_DIR"; return 0
     fi
     if [ -f "$STATE_FILE" ]; then
         # shellcheck disable=SC1090
@@ -203,6 +204,87 @@ cmd_status() {
 
 cmd_where() { require_repo_dir; }
 
+# Print a check line: pass (✓), warn (!), or fail (✗) plus a message.
+_check() {
+    case "$1" in
+        pass) ok "$2";;
+        warn) warn "$2";;
+        fail) printf '\033[0;31m  ✗\033[0m %s\n' "$2" >&2;;
+    esac
+}
+
+cmd_doctor() {
+    local problems=0
+
+    info "Checking your dotsync setup"
+
+    # git present (critical)
+    if command -v git >/dev/null 2>&1; then
+        _check pass "git is installed ($(git --version | awk '{print $3}'))"
+    else
+        _check fail "git is not installed — install it first"
+        problems=$((problems + 1))
+    fi
+
+    # dotsync on PATH
+    if command -v "$PROG" >/dev/null 2>&1; then
+        _check pass "$PROG is on your PATH ($(command -v "$PROG"))"
+    else
+        _check warn "$PROG is not on your PATH — add ~/.local/bin to PATH"
+    fi
+
+    # config repo resolved
+    local repo=""
+    if repo="$(resolve_repo_dir 2>/dev/null)" && [ -d "$repo" ]; then
+        _check pass "config repo: $repo"
+    else
+        _check warn "no config repo set — run '$PROG init <repo-url>' or '$PROG use <dir>'"
+        info "Nothing more to check until a config repo is set."
+        [ "$problems" -eq 0 ] && return 0 || return 1
+    fi
+
+    # remote reachability / auth (read-only)
+    if git -C "$repo" remote get-url origin >/dev/null 2>&1; then
+        if git -C "$repo" ls-remote --exit-code origin >/dev/null 2>&1; then
+            _check pass "remote 'origin' is reachable and authenticated"
+        else
+            _check fail "cannot reach/authenticate 'origin' — try 'gh auth login', add an SSH key, or configure a git credential helper"
+            problems=$((problems + 1))
+        fi
+    else
+        _check warn "config repo has no 'origin' remote (push/pull will not work)"
+    fi
+
+    # manifest + link status
+    if [ -f "$repo/sync.map" ]; then
+        _check pass "manifest found: $repo/sync.map"
+        each_mapping "$repo" _doctor_one
+    else
+        _check fail "no sync.map in $repo"
+        problems=$((problems + 1))
+    fi
+
+    if [ "$problems" -eq 0 ]; then
+        info "All good."
+        return 0
+    fi
+    info "$problems problem(s) found."
+    return 1
+}
+
+_doctor_one() {
+    local src="$1" target="$2" rel="$3"
+    if [ ! -e "$src" ]; then
+        _check fail "$rel: source missing ($src)"
+    elif [ -L "$target" ] && [ "$(readlink "$target")" = "$src" ]; then
+        _check pass "$rel: linked"
+    elif [ -e "$target" ] || [ -L "$target" ]; then
+        _check warn "$rel: exists but not linked to the repo (run '$PROG link')"
+    else
+        _check warn "$rel: not linked yet (run '$PROG link')"
+    fi
+}
+
 cmd_help() {
     cat <<EOF
 $PROG — keep your git & shell config in sync across machines
@@ -216,11 +298,12 @@ Usage:
   $PROG push [message]          Commit all changes and push
   $PROG pull                    Pull latest, then re-link
   $PROG status                  Show the config repo's git status
+  $PROG doctor                  Diagnose your setup (git, PATH, auth, links)
   $PROG where                   Print the resolved config repo path
   $PROG help                    Show this help
 
 The active config repo is resolved in this order:
-  1. \$GIT_CONFIG_SYNC_DIR
+  1. \$DOTSYNC_DIR
   2. the path saved by init/use ($STATE_FILE)
   3. the repository this script lives in (if it contains a sync.map)
 EOF
@@ -237,6 +320,7 @@ main() {
         push)             cmd_push "$@";;
         pull)             cmd_pull "$@";;
         status)           cmd_status "$@";;
+        doctor)           cmd_doctor "$@";;
         where)            cmd_where "$@";;
         help|-h|--help)   cmd_help;;
         *) die "Unknown command '$cmd'. Run '$PROG help'.";;

--- a/bin/dotsync
+++ b/bin/dotsync
@@ -60,8 +60,14 @@ resolve_repo_dir() {
         local REPO_DIR=""; source "$STATE_FILE"
         [ -n "$REPO_DIR" ] && { printf '%s\n' "$REPO_DIR"; return 0; }
     fi
-    local self_repo; self_repo="$(dirname "$(script_dir)")"   # bin/ -> repo root
-    if [ -f "$self_repo/sync.map" ]; then
+    # Fall back to the repo this script lives in — but NOT when that repo is the
+    # CLI's own install location (~/.local/share/dotsync). A `curl | bash` install
+    # is "CLI only": its bundled sample config must never be auto-adopted as the
+    # user's config repo just because it happens to ship a sync.map.
+    local self_repo install_dir
+    self_repo="$(dirname "$(script_dir)")"   # bin/ -> repo root
+    install_dir="${XDG_DATA_HOME:-$HOME/.local/share}/dotsync"
+    if [ -f "$self_repo/sync.map" ] && [ "$self_repo" != "$install_dir" ]; then
         printf '%s\n' "$self_repo"; return 0
     fi
     return 1
@@ -276,6 +282,7 @@ _doctor_one() {
     local src="$1" target="$2" rel="$3"
     if [ ! -e "$src" ]; then
         _check fail "$rel: source missing ($src)"
+        problems=$((problems + 1))
     elif [ -L "$target" ] && [ "$(readlink "$target")" = "$src" ]; then
         _check pass "$rel: linked"
     elif [ -e "$target" ] || [ -L "$target" ]; then

--- a/config/bashrc.aliases
+++ b/config/bashrc.aliases
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# git-config-sync — shell aliases
+# dotsync — shell aliases
 #
-# This block is appended to your ~/.bashrc by `git-config-sync link` (or
+# This block is appended to your ~/.bashrc by `dotsync link` (or
 # install.sh). It is wrapped in BEGIN/END markers so it can be safely
 # re-applied and later removed without touching the rest of your ~/.bashrc.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/config/gitconfig
+++ b/config/gitconfig
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# git-config-sync — sample global git config
+# dotsync — sample global git config
 #
-# This file is symlinked to ~/.gitconfig by `git-config-sync link` (or install.sh).
+# This file is symlinked to ~/.gitconfig by `dotsync link` (or install.sh).
 # Replace the placeholders in the [user]/[github] sections with your own values,
 # or set them once with:
 #

--- a/install.sh
+++ b/install.sh
@@ -1,54 +1,86 @@
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────────────────────
-# git-config-sync — one-shot installer for this repository.
+# dotsync — installer
 #
-# It will:
-#   1. Install the `git-config-sync` CLI into ~/.local/bin
-#   2. Symlink the tracked config files (see sync.map) into $HOME, backing up
-#      anything already there as <file>.bak
-#   3. Append the shell aliases block to your ~/.bashrc (idempotent)
-#   4. Optionally apply the npm security defaults (scripts/secure-packages.sh)
+# Install just the CLI, straight from the internet:
 #
-# Re-running is safe: existing links are left untouched.
+#     curl -fsSL https://raw.githubusercontent.com/adonyssantos/dotsync/main/install.sh | bash
+#
+# Or run it from a local clone to also set up this repo's own dotfiles:
+#
+#     git clone https://github.com/adonyssantos/dotsync.git
+#     bash dotsync/install.sh
+#
+# What it does:
+#   1. Installs the `dotsync` CLI into ~/.local/bin (cloning the repo to
+#      ~/.local/share/dotsync first when run via curl).
+#   2. When run interactively from inside a clone, offers to symlink that repo's
+#      config into $HOME (backing up existing files) and apply npm defaults.
+#
+# Re-running is safe.
 # ─────────────────────────────────────────────────────────────────────────────
 
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_URL="${DOTSYNC_REPO_URL:-https://github.com/adonyssantos/dotsync.git}"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/dotsync"
 BIN_DIR="$HOME/.local/bin"
 
-echo "This installer will:"
-echo "  - Install the git-config-sync CLI to $BIN_DIR"
-echo "  - Symlink config files from this repo into \$HOME (backing up existing ones)"
-echo "  - Append shell aliases to ~/.bashrc (safe to re-run)"
-echo "  - Apply npm security defaults (optional)"
-echo ""
-read -r -p "Continue? (y/N) " choice
-[ "$choice" = "y" ] || { echo "Aborted."; exit 1; }
+# Interactive only when stdin is a real terminal (never under `curl | bash`).
+interactive() { [ -t 0 ]; }
 
-# ── 1. Install the CLI ─────────────────────────────────────────────────────
-chmod +x "$REPO_DIR/bin/git-config-sync"
+# ── Resolve where the repo (and thus the CLI) lives ──────────────────────────
+SELF="${BASH_SOURCE[0]:-}"
+if [ -n "$SELF" ] && SELF_DIR="$(cd "$(dirname "$SELF")" 2>/dev/null && pwd)" \
+        && [ -f "$SELF_DIR/bin/dotsync" ]; then
+    # Running from inside a clone — use it directly.
+    REPO_DIR="$SELF_DIR"
+    IN_REPO=1
+else
+    # Piped from curl (or no local copy): clone/update into DATA_DIR.
+    IN_REPO=0
+    if [ -d "$DATA_DIR/.git" ]; then
+        echo "==> Updating existing clone at $DATA_DIR"
+        git -C "$DATA_DIR" pull --ff-only
+    else
+        echo "==> Cloning $REPO_URL into $DATA_DIR"
+        mkdir -p "$(dirname "$DATA_DIR")"
+        git clone "$REPO_URL" "$DATA_DIR"
+    fi
+    REPO_DIR="$DATA_DIR"
+fi
+
+# ── 1. Install the CLI ───────────────────────────────────────────────────────
+chmod +x "$REPO_DIR/bin/dotsync"
 mkdir -p "$BIN_DIR"
-ln -sf "$REPO_DIR/bin/git-config-sync" "$BIN_DIR/git-config-sync"
-echo "==> Installed CLI: $BIN_DIR/git-config-sync"
+ln -sf "$REPO_DIR/bin/dotsync" "$BIN_DIR/dotsync"
+echo "==> Installed CLI: $BIN_DIR/dotsync -> $REPO_DIR/bin/dotsync"
 case ":$PATH:" in
     *":$BIN_DIR:"*) ;;
     *) echo "  ! $BIN_DIR is not on your PATH. Add this to your shell rc:"
        echo "        export PATH=\"\$HOME/.local/bin:\$PATH\"" ;;
 esac
 
-# ── 2 & 3. Link config files + aliases ─────────────────────────────────────
-GIT_CONFIG_SYNC_DIR="$REPO_DIR" "$REPO_DIR/bin/git-config-sync" link
-
-# ── 4. npm security defaults (optional) ────────────────────────────────────
-echo ""
-read -r -p "Apply npm security defaults (save-exact, ignore-scripts, min-release-age)? (y/N) " sec
-if [ "$sec" = "y" ]; then
-    bash "$REPO_DIR/scripts/secure-packages.sh"
+# ── 2. Optionally set up THIS repo's dotfiles (interactive, in-repo only) ─────
+if [ "$IN_REPO" -eq 1 ] && interactive; then
+    echo ""
+    read -r -p "Also symlink this repo's config into \$HOME (backs up existing files)? (y/N) " link_choice
+    if [ "$link_choice" = "y" ]; then
+        DOTSYNC_DIR="$REPO_DIR" "$REPO_DIR/bin/dotsync" link
+        echo ""
+        read -r -p "Apply npm security defaults (save-exact, ignore-scripts, min-release-age)? (y/N) " sec
+        if [ "$sec" = "y" ]; then
+            bash "$REPO_DIR/scripts/secure-packages.sh"
+        fi
+    fi
 fi
 
+# ── Done ─────────────────────────────────────────────────────────────────────
 echo ""
-echo "Done. Open a new terminal or run 'source ~/.bashrc' to load the aliases."
-echo "Remember to set your git identity:"
-echo "    git config --global user.name  \"Your Name\""
-echo "    git config --global user.email \"you@example.com\""
+echo "Done. Next steps:"
+echo "  1. Make sure ~/.local/bin is on your PATH (see above if warned)."
+echo "  2. Point dotsync at your dotfiles repo:"
+echo "        dotsync init https://github.com/<you>/<your-dotfiles>.git"
+echo "        dotsync link"
+echo "  3. Check everything is wired up:"
+echo "        dotsync doctor"

--- a/sync.map
+++ b/sync.map
@@ -1,7 +1,7 @@
-# git-config-sync manifest
+# dotsync manifest
 #
 # Each non-comment line maps a file tracked in this repository to a destination
-# under your $HOME. `git-config-sync link` creates a symlink at the destination
+# under your $HOME. `dotsync link` creates a symlink at the destination
 # pointing back at the repo file, so edits stay in sync in both directions.
 #
 # Format:  <source (relative to repo root)>   <target (relative to $HOME)>


### PR DESCRIPTION
Closes part of #4 — takes the console sync program from a working prototype to something easy to install and diagnose, after the repository was renamed to `dotsync`. Intentionally avoids scope creep (no bundled auth, no npm/binary yet).

## What's included

### Rename `git-config-sync` → `dotsync`
- `bin/git-config-sync` → `bin/dotsync`; internal name, help text and header updated.
- State dir moved to `~/.config/dotsync`; shell-alias markers are now `# BEGIN/END dotsync aliases`.
- Environment variable `GIT_CONFIG_SYNC_DIR` → `DOTSYNC_DIR`.
- References updated across `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `config/gitconfig`, `config/bashrc.aliases`, `sync.map` (no old references remain).

### New `doctor` command
Diagnoses the setup and guides the user:
- git installed, `dotsync` on `PATH`, config repo resolved and present.
- Remote reachability/authentication via a read-only `git ls-remote`, with a hint (`gh auth login`, SSH key, or a git credential helper) when it fails.
- Per-file link status from `sync.map` (linked / not linked / conflicting).

This is the practical replacement for the issue's proposed `login --github`: auth is delegated to git rather than reimplemented.

### Standalone installer (`install.sh`)
- `curl -fsSL https://raw.githubusercontent.com/adonyssantos/dotsync/main/install.sh | bash` clones the repo into `~/.local/share/dotsync` and symlinks the CLI into `~/.local/bin` (CLI only).
- Run from a local clone **interactively**, it also offers to symlink this repo's own config and apply the npm defaults.
- `[ -t 0 ]` guard: piped/non-interactive runs skip all prompts. Re-running updates the existing clone (idempotent).

### Docs
- **Installation** section: one-line `curl | bash`, manual install, and **Windows (Git Bash / WSL)** notes.
- `doctor` added to the CLI reference table.
- **Design decisions & roadmap** section: auth delegated to git (why no bundled login), npm package and prebuilt binaries deferred (with the `curl`/Homebrew alternative), and the web "catalog" idea kept as a separate project. Documents the command mapping: the issue's `set <folder> <repo>` ≈ `dotsync init <repo> [dir]`.

## Command surface
Kept to `init` / `use` (canonical) instead of `set-folder` / `set-repo`; the mapping is documented so users coming from #4 aren't lost.

## Verification
- `bash -n` clean on `bin/dotsync`, `install.sh`, `scripts/secure-packages.sh`.
- End-to-end against a throwaway `$HOME`: `doctor` (reports unlinked → linked), `link` (with backups), `unlink` (restores backups); state dir named `dotsync`.
- Installer tested both in-repo (non-interactive, CLI-only) and bootstrap (piped, offline via a `file://` remote); re-run updates the clone.